### PR TITLE
Added missing view operation and corrected a type->type undefined issue.

### DIFF
--- a/queues.module
+++ b/queues.module
@@ -144,11 +144,11 @@ function queues_permission() {
   $permissions = array(
     'administer queue types' => array(
       'title' => t('Administer queue types'),
-      'description' => t('Create and delete fields for queue types, and set their permissions.'),
+      'description' => t('Create, view, and delete fields for queue types, and set their permissions.'),
     ),
     'administer queue' => array(
       'title' => t('Administer queues'),
-      'description' => t('Edit and delete all queues'),
+      'description' => t('View, edit, and delete all queues'),
     ),
   );
 
@@ -156,6 +156,9 @@ function queues_permission() {
   foreach (queues_type_get_types() as $type) {
     $type_name = check_plain($type->type);
     $permissions += array(
+      "view any $type_name queue" => array(
+        'title' => t('%type_name: View any queue', array('%type_name' => $type->label)),
+      ),
       "edit any $type_name queue" => array(
         'title' => t('%type_name: Edit any queue', array('%type_name' => $type->label)),
       ),
@@ -231,9 +234,15 @@ function queue_entity_access($op = 'edit', $queue = NULL, $account = NULL) {
     return TRUE;
   }
   if (isset($queue) && $type_name = $queue->type) {
-    $type_name = check_plain($type->type);
+    $type_name = check_plain($queue->type);
 
     switch ($op) {
+      case 'view':
+        if (user_access("view any $type_name queue", $account)) {
+          return TRUE;
+        }
+        break;
+
       case 'edit':
         if (user_access("edit any $type_name queue", $account)) {
           return TRUE;


### PR DESCRIPTION
Resolves #2 

This PR adds in a $op view for queues.  As i mentioned in #2 the guts of having this work in the view entity page already exist for some reason the actual operation was omitted however and thus when the view operation was checked against it was always failing.

I also corrected an issue with the undefined $type->type on line 234.
